### PR TITLE
[day5] yunu: 프로그래머스 - 이모티콘 할인행사

### DIFF
--- a/yunu/programmers/이모티콘 할인행사.js
+++ b/yunu/programmers/이모티콘 할인행사.js
@@ -1,0 +1,45 @@
+function solution(users, emoticons) {
+  const getDiscountPrice = (discount, price) => (price * (10 - discount)) / 10;
+
+  const totalPrice = [];
+
+  const setSum = (discount, price) => {
+    return (sum, index) => {
+      if (index + 1 > discount) return sum;
+      return sum + getDiscountPrice(discount, price);
+    };
+  };
+
+  const getTotalSum = (discountSum, i) => {
+    if (i === emoticons.length) {
+      totalPrice.push(discountSum);
+      return;
+    }
+    getTotalSum(discountSum.map(setSum(1, emoticons[i])), i + 1);
+    getTotalSum(discountSum.map(setSum(2, emoticons[i])), i + 1);
+    getTotalSum(discountSum.map(setSum(3, emoticons[i])), i + 1);
+    getTotalSum(discountSum.map(setSum(4, emoticons[i])), i + 1);
+  };
+
+  getTotalSum([0, 0, 0, 0], 0);
+
+  let answer = [0, 0];
+  totalPrice.forEach(prices => {
+    const result = [0, 0];
+    users.forEach(([want, maxPrice]) => {
+      want = parseInt((want + 9) / 10);
+      if (prices[want - 1] >= maxPrice) {
+        result[0]++;
+      } else {
+        result[1] += prices[want - 1];
+      }
+    });
+    if (answer[0] < result[0]) {
+      answer = result;
+    } else if (answer[0] === result[0] && answer[1] < result[1]) {
+      answer = result;
+    }
+  });
+
+  return answer;
+}


### PR DESCRIPTION
## 문제 링크 🌟
- [이모티콘 할인행사](https://school.programmers.co.kr/learn/courses/30/lessons/150368)


## 문제 간단 설명 😇
- 이모티콘의 할인율 중 어떤 할인율이 이모티콘 플러스 서비스 가입자를 최대한 늘리고 이모티콘의 판매액을 최대한 늘릴 수 있는지 구하기
- 이모티콘 플러스 서비스 가입자 수가 판매액보다 더 우선순위가 높다.

## 문제 풀이 🙂
- 완전탐색으로 접근하면 시간복잡도가 4^7 * 100 * 7로 약 10,000,000로 계산되었다. (맞는지는 모름)
- 각 할인율을 누적시키면서 저장하여 시간을 7배 줄일 수 있었다.
- 예를들어 10%이상이면 10, 20, 30, 40 모두 포함되기 때문에 모두 누적해서 저장하였다.
