### PR TITLE
[day3] yunu: 프로그래머스 - 양과 늑대

### DIFF
--- a/yunu/프로그래머스/양과 늑대/내 코드.js
+++ b/yunu/프로그래머스/양과 늑대/내 코드.js
@@ -1,0 +1,99 @@
+function solution(info, edges) {
+  const graph = {};
+  edges.forEach(([start, end]) => {
+    if (!graph[start]) graph[start] = [end];
+    else graph[start].push(end);
+  });
+
+  let answer = 0;
+  const stack = [{ sheep: 1, wolf: 0, nodes: graph[0] }];
+  while (stack.length) {
+    const { sheep, wolf, nodes } = stack.pop();
+    if (sheep <= wolf) continue;
+    answer = Math.max(answer, sheep);
+    for (let i = 0; i < nodes.length; i++) {
+      if (info[nodes[i]] === 0) {
+        stack.push({
+          sheep: sheep + 1,
+          wolf,
+          nodes: [
+            ...nodes.filter((_, index) => i !== index),
+            ...(graph[nodes[i]] || []),
+          ],
+        });
+      } else {
+        stack.push({
+          sheep,
+          wolf: wolf + 1,
+          nodes: [
+            ...nodes.filter((_, index) => i !== index),
+            ...(graph[nodes[i]] || []),
+          ],
+        });
+      }
+    }
+  }
+
+  return answer;
+}
+
+console.log(
+  solution(
+    [0, 0, 1, 1, 1, 0, 1, 0, 1, 0, 1, 1],
+    [
+      [0, 1],
+      [1, 2],
+      [1, 4],
+      [0, 8],
+      [8, 7],
+      [9, 10],
+      [9, 11],
+      [4, 3],
+      [6, 5],
+      [4, 6],
+      [8, 9],
+    ]
+  )
+);
+
+console.log(
+  solution(
+    [0, 1, 0, 1, 1, 0, 1, 0, 0, 1, 0],
+    [
+      [0, 1],
+      [0, 2],
+      [1, 3],
+      [1, 4],
+      [2, 5],
+      [2, 6],
+      [3, 7],
+      [4, 8],
+      [6, 9],
+      [9, 10],
+    ]
+  )
+);
+
+console.log(
+  solution(
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [
+      [0, 1],
+      [0, 2],
+      [1, 3],
+      [1, 4],
+      [2, 5],
+      [2, 6],
+      [3, 7],
+      [3, 8],
+      [4, 9],
+      [4, 10],
+      [5, 11],
+      [5, 12],
+      [6, 13],
+      [6, 14],
+      [7, 15],
+      [7, 16],
+    ]
+  )
+);

--- a/yunu/프로그래머스/양과 늑대/좋은 코드.js
+++ b/yunu/프로그래머스/양과 늑대/좋은 코드.js
@@ -1,0 +1,127 @@
+// 바킹독 풀이
+function solution(info, edges) {
+  const left = Array(20).fill(-1);
+  const right = Array(20).fill(-1);
+
+  edges.forEach(([parent, child]) => {
+    if (left[parent] === -1) left[parent] = child;
+    else right[parent] = child;
+  });
+
+  let answer = 0;
+  const visited = Array(1 << 17).fill(0);
+  const solve = state => {
+    if (visited[state]) return;
+    visited[state] = 1;
+
+    let wolf = 0;
+    let total = 0;
+
+    for (let i = 0; i < info.length; i++) {
+      if (state & (1 << i)) {
+        total++;
+        wolf += info[i];
+      }
+    }
+    if (2 * wolf >= total) return;
+    answer = Math.max(answer, total - wolf);
+
+    for (let i = 0; i < info.length; i++) {
+      if (!(state & (1 << i))) continue;
+      if (left[i] !== -1) solve(state | (1 << left[i]));
+      if (right[i] !== -1) solve(state | (1 << right[i]));
+    }
+  };
+  solve(1);
+  return answer;
+}
+
+// 바킹독 풀이에서 left, right를 보기 좋게 바꿈
+function solution(info, edges) {
+  const graph = {};
+  edges.forEach(([start, end]) => {
+    if (!graph[start]) graph[start] = [end];
+    else graph[start].push(end);
+  });
+
+  let answer = 0;
+  const visited = Array(1 << 17).fill(0);
+  const solve = (state, wolf, total) => {
+    if (visited[state]) return;
+    visited[state] = 1;
+
+    if (2 * wolf >= total) return;
+    answer = Math.max(answer, total - wolf);
+
+    for (let i = 0; i < info.length; i++) {
+      if (!(state & (1 << i))) continue;
+      for (const next of graph[i] || []) {
+        solve(state | (1 << next), wolf + info[next], total + 1);
+      }
+    }
+  };
+
+  solve(1, 0, 1);
+  return answer;
+}
+
+console.log(
+  solution(
+    [0, 0, 1, 1, 1, 0, 1, 0, 1, 0, 1, 1],
+    [
+      [0, 1],
+      [1, 2],
+      [1, 4],
+      [0, 8],
+      [8, 7],
+      [9, 10],
+      [9, 11],
+      [4, 3],
+      [6, 5],
+      [4, 6],
+      [8, 9],
+    ]
+  )
+);
+
+console.log(
+  solution(
+    [0, 1, 0, 1, 1, 0, 1, 0, 0, 1, 0],
+    [
+      [0, 1],
+      [0, 2],
+      [1, 3],
+      [1, 4],
+      [2, 5],
+      [2, 6],
+      [3, 7],
+      [4, 8],
+      [6, 9],
+      [9, 10],
+    ]
+  )
+);
+
+console.log(
+  solution(
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [
+      [0, 1],
+      [0, 2],
+      [1, 3],
+      [1, 4],
+      [2, 5],
+      [2, 6],
+      [3, 7],
+      [3, 8],
+      [4, 9],
+      [4, 10],
+      [5, 11],
+      [5, 12],
+      [6, 13],
+      [6, 14],
+      [7, 15],
+      [7, 16],
+    ]
+  )
+);


### PR DESCRIPTION
## 문제 링크 🌟
- [양과 늑대](https://school.programmers.co.kr/learn/courses/30/lessons/92343)


## 문제 간단 설명 😇
- 양과 늑대가 있는 그래프에서 늑대가 양보다 같거나 크지 않는 선에서 탐색할 수 있는 최대 양 마리 수를 구하는 문제

## 내 코드 풀이 🤨
- dfs를 사용해 현재 양 마리수, 늑대 마리수, 갈 수 있는 노드를 스택에 담아서 탐색을 진행했다.
- 갈 수 있는 노드 배열을 구하는 것이 조금 까다로웠는데 기존에 갈 수 있는 노드에서 현재 노드를 제외하고 다음에 갈 노드의 다음 노드들을 합쳐서 구했다.
- `splice`를 통해서 특정 인덱스의 노드를 지워봤는데 순수함수인 줄 알았는데 아니여서 `filter`를 통해 특정 인덱스를 삭제하였다.
- 다른 사람 풀이를 보니 `set`의 집합 연산을 통해 쉽게 처리한 것 같다.

## 좋은 코드 풀이 😄
- 대부분의 사람들이 dfs, bfs를  통해 풀었지만 이 경우 중복되는 경우가 발생해 특정 테스트케이스에서 시간초과가 날 수 있다고 한다. (카카오 공식 테스트케이스에는 없다.)
- info의 길이가 17인 것을 보면 충분히 비트마스킹을 통해 visited를 확인할 수 있어 크기가 `1 << 17`인 visited 배열을 만든다.
- `&` 비트연산자를 통해 해당 비트가 1인지 확인하고 `|` 비트연산자를 통해 해당 위치에 1을 넣어주어 visited를 관리한다.
- 이후는 기존 풀이와 똑같이하면 된다.
- (양의 수와 늑대의 수)보다 (전체의 수와 늑대의 수)로 갈 수 있는지 판단하는것이 더 편한 것 같다. (이런 센스 좀 배우고 싶네..)

## 기타 😭
- 이전에 풀었을 때 고생했던 기억 때문에 이번에 쉽게 풀 줄 알았지만 또 고생했다.
- 이전 풀이도 질문하기에서 보니까 잘못된 풀이라는 것을 알게 되었다.