### PR TITLE
[day1] yunu: 프로그래머스 - 시소 짝꿍, 110 옮기기

### DIFF
--- a/yunu/프로그래머스/110 옮기기/내 코드.js
+++ b/yunu/프로그래머스/110 옮기기/내 코드.js
@@ -1,0 +1,34 @@
+function solution(s) {
+  const popTop = stack => {
+    if (stack.length < 3) return false;
+    if ('110' === stack.slice(stack.length - 3, stack.length).join('')) {
+      stack.pop();
+      stack.pop();
+      stack.pop();
+      return true;
+    }
+    return false;
+  };
+
+  return s.map(str => {
+    const strArr = [...str].reverse();
+    let count = 0;
+    const stack = [];
+    while (strArr.length) {
+      const next = strArr.pop();
+      stack.push(next);
+      if (next === '1') continue;
+      if (popTop(stack)) count++;
+    }
+    const total = '110'.repeat(count);
+    str = stack.join('');
+    const index = str.lastIndexOf('0');
+    if (index !== -1) {
+      return str.substring(0, index + 1) + total + str.substring(index + 1);
+    }
+    return total + str;
+  });
+}
+
+console.log(solution(['1110', '100111100', '0111111010']));
+console.log(solution(['1100111011101001']));

--- a/yunu/프로그래머스/110 옮기기/좋은 코드.js
+++ b/yunu/프로그래머스/110 옮기기/좋은 코드.js
@@ -1,0 +1,21 @@
+function solution(s) {
+  return s.map(str => {
+    let left = '',
+      count1 = 0,
+      count110 = 0;
+    for (const c of str) {
+      if (c === '1') count1++;
+      else if (count1 >= 2) {
+        count1 -= 2;
+        count110++;
+      } else {
+        left += count1 > 0 ? '10' : '0';
+        count1 = 0;
+      }
+    }
+    return left + '110'.repeat(count110) + '1'.repeat(count1);
+  });
+}
+
+console.log(solution(['1110', '100111100', '0111111010']));
+console.log(solution(['1100111011101001']));

--- a/yunu/프로그래머스/시소 짝꿍/내 코드.js
+++ b/yunu/프로그래머스/시소 짝꿍/내 코드.js
@@ -1,0 +1,26 @@
+function solution(weights) {
+  const cases = [4 / 3, 3 / 2, 2];
+
+  const dict = {};
+  weights.forEach(weight => {
+    if (!dict[weight]) dict[weight] = 1;
+    else dict[weight]++;
+  });
+
+  let answer = 0;
+  Object.keys(dict)
+    .sort((a, b) => parseInt(a) - parseInt(b))
+    .forEach(weight => {
+      weight = parseInt(weight);
+      answer += (dict[weight] * (dict[weight] - 1)) / 2;
+      cases.forEach(num => {
+        if (dict[weight * num]) {
+          answer += dict[weight] * dict[weight * num];
+        }
+      });
+    });
+
+  return answer;
+}
+
+console.log(solution([100, 180, 360, 100, 270]));

--- a/yunu/프로그래머스/시소 짝꿍/좋은 코드.js
+++ b/yunu/프로그래머스/시소 짝꿍/좋은 코드.js
@@ -1,0 +1,27 @@
+function solution(weights) {
+  weights.sort((a, b) => b - a);
+  const cache = {};
+  let cnt = 0;
+  for (let n of weights) {
+    let m;
+    if (cache[n]) {
+      cnt += cache[n];
+    }
+    if (((m = (n * 3) / 2), cache[m])) {
+      cnt += cache[m];
+    }
+    if (((m = n * 2), cache[m])) {
+      cnt += cache[m];
+    }
+    if (((m = (n * 4) / 3), cache[m])) {
+      cnt += cache[m];
+    }
+
+    if (!cache[n]) cache[n] = 1;
+    else cache[n]++;
+  }
+
+  return cnt;
+}
+
+console.log(solution([100, 180, 360, 100, 270]));


### PR DESCRIPTION
## 문제 링크 🌟
- [시소 짝꿍](https://school.programmers.co.kr/learn/courses/30/lessons/152996)
- [110 옮기기](https://school.programmers.co.kr/learn/courses/30/lessons/77886)

## 문제 간단 설명 😇
### 시소 짝꿍
- 주어진 몸무게 목록에서 2 사람을 골라 시소 짝꿍이 될 수 있는 모든 쌍을 구하는 문제
- 시소는 2, 3, 4 m 마다 좌석이 있어 두 사람의 몸무게가 같지 않더라도 짝꿍이 될 수 있다.

### 110 옮기기
- 1와 0으로 이루어진 문자열에서 110을 옮겨 만들 수 있는 가작 작은 문자열을 구하는 문제
- 110을 옮기는 과정에서 새로운 110이 생길 수 있다.

## 내 코드 풀이 🤨
### 시소 짝꿍
- 파이썬의 `dict` 자료구조로 각 몸무게 별 사람수를 저장한다.
- 한 사람을 기준으로 더 무거운 사람과 비교할 때 가능한 배수인 `4/3`, `3/2`, `2`가 있는지 dict에서 확인한다.
- 같은 몸무게인 사람들은 모두 별게의 사람으로 조합을 이용해서 `nC2`이렇게 구해줘야 한다.
- 다른 몸무게인 사람들은 그 몸무게의 사람 수를 더하면 된다.

### 110 옮기기
- 첫번째 시도로 `110`로 `split`하고 개수 세고 이후 `split`한 배열을 합치고 다시 `split` 분리가 안될때 까지 반복했다.
- 이 경우 시간초과가 나서 시간을 단축시켜야 했다.
- 스택을 이용해서 시간을 단축시킬 수 있다.
- 주어진 문자열을 하나씩 스택에 집어 넣고 만약 위에서부터 `110`이라면 `pop`하고 `count++`를 한다.
- 모두 완료하면 위에서부터 `0`을 처음 만날때 `index`에 `110 * count`를 집어 넣으면 된다.
- `0`이 없는 경우는 따로 예외처리를 해준다.

## 좋은 코드 풀이 😱
### 시소 짝꿍
- 내 코드 풀이와 비슷하지만 같은 몸무게인 사람들끼리 조합을 하는 것이 아닌 신기하게 구했다.
- 몸무게가 같은 사람이 n명 있으면
- `1`, `n - 1`로 분리하고 보면 `n - 1`명 중에서 2명 고르는 방법 + `1`과 `n - 1`명을 2명씩 짝짓는 방법 `n - 1`하여 구할 수 있다.
- `f(n) = f(n- 1) + n - 1` 이렇게 나오는데 이런 식으로 코드를 짜신 것 같다. 2명을 고르는 경우가 좀 특이한 케이스 같다.

### 110 옮기기
- `left`, `1로만 이루어진 문자열 수(count1)`, `110의 개수(count110)` 세 배열을 만들고 주어진 문자열을 순회한다.
- 문자가 `1`인 경우 `count1++`
- 문자가 `0`이면서 `count1`이 `2`이상이면 `110`을 만들 수 있으므로 `count1 -= 2`하고 `count110++`을 한다.
- 문자가 `0`이면서 `count1`이 `2`미만이면 더 이상 `110`을 만들 수 없다. `count1`이 `0`보다 크면 `10`을 아니면 `0`을 `left`에 추가한다.
- 이후 `left` + `110을 count110만큼 반복한 문자열` + `1을 count1만큼 반복한 문자열`이 답이 된다.

### 기타 😰
- 시소 문제는 몸무게의 짝이 같은 경우는 중복해서 세야되는 줄 모르고 엄청 틀린 것 같다. 이런 건 문제에서 명확히 해줬으면 좋겠다. (~~변명아님~~)
- 110 문제에서 스택의 필요성을 늦게 깨달았다. 이번 문제를 계기로 스택 유형도 상기하면서 문제를 풀어야 겠다.
