### PR TITLE
[day5] yunu: 프로그래머스 - 무인도 여행

### DIFF
--- a/yunu/프로그래머스/무인도 여행/내 코드.js
+++ b/yunu/프로그래머스/무인도 여행/내 코드.js
@@ -1,0 +1,39 @@
+function solution(maps) {
+  const visited = Array.from(Array(maps.length), () =>
+    Array(maps[0].length).fill(false)
+  );
+
+  const dx = [1, 0, -1, 0];
+  const dy = [0, 1, 0, -1];
+
+  const getDays = (x, y) => {
+    let res = parseInt(maps[x][y]);
+    visited[x][y] = true;
+    for (let i = 0; i < 4; i++) {
+      const nextX = x + dx[i];
+      const nextY = y + dy[i];
+      if (
+        nextX < 0 ||
+        nextY < 0 ||
+        nextX >= maps.length ||
+        nextY >= maps[0].length
+      )
+        continue;
+      if (maps[nextX][nextY] === 'X') continue;
+      if (visited[nextX][nextY]) continue;
+      res += getDays(nextX, nextY);
+    }
+    return res;
+  };
+
+  const answer = [];
+
+  for (let i = 0; i < maps.length; i++) {
+    for (let j = 0; j < maps[0].length; j++) {
+      if (maps[i][j] === 'X' || visited[i][j]) continue;
+      answer.push(getDays(i, j));
+    }
+  }
+
+  return answer.length === 0 ? [-1] : answer.sort((a, b) => a - b);
+}

--- a/yunu/프로그래머스/무인도 여행/좋은 코드.js
+++ b/yunu/프로그래머스/무인도 여행/좋은 코드.js
@@ -1,0 +1,38 @@
+function solution(maps) {
+  maps = maps.map(row => [...row]);
+
+  const dx = [1, 0, -1, 0];
+  const dy = [0, 1, 0, -1];
+
+  const getDays = (x, y) => {
+    let res = parseInt(maps[x][y]);
+    maps[x][y] = 'X';
+    for (let i = 0; i < 4; i++) {
+      const nextX = x + dx[i];
+      const nextY = y + dy[i];
+      if (
+        nextX < 0 ||
+        nextY < 0 ||
+        nextX >= maps.length ||
+        nextY >= maps[0].length
+      )
+        continue;
+      if (maps[nextX][nextY] === 'X') continue;
+      res += getDays(nextX, nextY);
+    }
+    return res;
+  };
+
+  const answer = [];
+
+  for (let i = 0; i < maps.length; i++) {
+    for (let j = 0; j < maps[0].length; j++) {
+      if (maps[i][j] === 'X') continue;
+      answer.push(getDays(i, j));
+    }
+  }
+
+  return answer.length === 0 ? [-1] : answer.sort((a, b) => a - b);
+}
+
+console.log(solution(['X591X', 'X1X5X', 'X231X', '1XXX1']));


### PR DESCRIPTION
## 문제 링크 🌟
- [무인도 여행](https://school.programmers.co.kr/learn/courses/30/lessons/154540)

## 문제 간단 설명 😇
- 주어진 맵에서 숫자로 이루어진 무인도(X로 동서남북이 가로막힌 지형)의 숫자합을 구하고 각 무인도를 오름차순으로 정렬하는 문제

## 내 코드 풀이 🤨
- `visited`를 만들어 내가 방문했는지 검사하면서 각 무인도에서 dfs를 해준다. `bfs`를 해줘도 상관없을듯

## 좋은 코드 풀이  🤗
- `visited`를 만들어준 내 코드와 다르게 기존의 `maps` 배열을 재사용하여 방문한 경우 'X'로 해준다.
- 주의할 점은 주어진 `maps`은 문자열로 이루어진 1차원 배열이므로 문자로 이루어진 2차원 배열로 변환해주어야 한다. 처음에는 오류가 안 나서 뭐지 했지만 문자열은 원시값이기 때문에 바꿀 수도 없고 바꿀려고 시도하더라도 에러를 발생시키지 않는다.
