### PR TITLE
wonseok

### DIFF
--- a/wonseok/bfs_dfs/2206_bfs.py
+++ b/wonseok/bfs_dfs/2206_bfs.py
@@ -1,0 +1,37 @@
+from sys import stdin
+from collections import deque
+
+n, m = map(int, input().split())
+
+matrix = [list(map(int, input())) for _ in range(n)]
+result = [[[0] * 2 for _ in range(m)] for _ in range(n)]
+result[0][0][0] = 1
+
+dx = [-1, 1, 0, 0]
+dy = [0, 0, -1, 1]
+
+
+def bfs():
+    queue = deque([(0, 0, 0)])
+
+    while queue:
+        x, y, flag = queue.popleft()
+
+        if x == n - 1 and y == m - 1:
+            return result[x][y][flag]
+
+        for i in range(4):
+            a = x + dx[i]
+            b = y + dy[i]
+            if a < 0 or a >= n or b < 0 or b >= m:
+                continue
+            if matrix[a][b] == 0 and result[a][b][flag] == 0:
+                result[a][b][flag] = result[x][y][flag] + 1
+                queue.append((a, b, flag))
+            if matrix[a][b] == 1 and flag == 0:
+                result[a][b][1] = result[x][y][0] + 1
+                queue.append((a, b, 1))
+    return -1
+
+
+print(bfs())


### PR DESCRIPTION
## 문제 링크 🌟

- [링크](https://www.acmicpc.net/problem/2206)


## 문제 간단 설명 😇

- 좌측최상단에서 우측최하단까지 가는 제일빠른길
- 이전에 푼 [미로탐색](https://www.acmicpc.net/problem/2178)과 비슷한 문제
- 그러나 벽을 한번 부술수있는 조건이 추가됨
## 내 코드 풀이 🤨
- 처음에는 result를 이차원배열로하고 벽을 파괴했는지의 유무를 flag변수로 했는데 계속 틀렸다고 나옴
- 이유는 벽을 부수고 계속탐색을 하는경우랑 벽을 안부수고 탐색을하는경우가 탐색을하다가 도중에 만나면 두값을 다 들고있는게 아니라 한개의 값만 가지고있다가(result가 이차원이라서) 벽을 한번더 만나는경우 -1이 되는경우가 발생해서임 (반례 -  9가나와야하는데 -1이 나왔음 처음에는
2 6
010001
000110
- 위 반례의 경우 1을 뚫고 간경우의 result로 덮어써져서 한번더 1을 만나는경우 -1이 나와버림 그냥 처음 1을 안뚫고 지나가면 되는데 그값이 지워져서그럼

- result를 3차원 배열로 바꾸고 벽을 부쉈을때 값이랑 안부쉈을때값둘다 가져간다
